### PR TITLE
Rename NOW_ON_PLAYING constant

### DIFF
--- a/app/src/main/java/com/halil/ozel/moviedb/dagger/modules/HttpClientModule.java
+++ b/app/src/main/java/com/halil/ozel/moviedb/dagger/modules/HttpClientModule.java
@@ -22,7 +22,7 @@ public class HttpClientModule {
 
     private static final long DISK_CACHE_SIZE = 50 * 1024 * 1024;
     public static final String TMDb_API_URL = "https://api.themoviedb.org/3/";
-    public static final String NOW_ON_PLAYING = "movie/now_playing";
+    public static final String NOW_PLAYING = "movie/now_playing";
     public static final String POPULAR = "movie/popular";
     public static final String MOVIE_DETAILS = "movie/";
 

--- a/app/src/main/java/com/halil/ozel/moviedb/data/Api/TMDbAPI.java
+++ b/app/src/main/java/com/halil/ozel/moviedb/data/Api/TMDbAPI.java
@@ -18,7 +18,7 @@ public interface TMDbAPI {
 
     String TMDb_API_KEY = "45dfdbd49fa1f1da1f5b75fd60217433";
 
-    @GET(HttpClientModule.NOW_ON_PLAYING)
+    @GET(HttpClientModule.NOW_PLAYING)
     Observable<ResponseNowPlaying> getNowPlaying(
             @Query("api_key") String api_key,
             @Query("page") int page


### PR DESCRIPTION
## Summary
- rename `NOW_ON_PLAYING` constant to `NOW_PLAYING`
- replace API usages to use the new constant

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68569873a7e4832bbc73ad2229aa1495