### PR TITLE
Add cast detail page with UI updates

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,8 @@
         <activity android:name=".ui.detail.MovieDetailActivity"
             android:screenOrientation="portrait"
             />
+        <activity android:name=".ui.detail.CastDetailActivity"
+            android:screenOrientation="portrait" />
         <activity
             android:exported="true"
             android:name=".ui.splash.SplashActivity">

--- a/app/src/main/java/com/halil/ozel/moviedb/dagger/components/ApplicationComponent.java
+++ b/app/src/main/java/com/halil/ozel/moviedb/dagger/components/ApplicationComponent.java
@@ -7,6 +7,7 @@ import com.halil.ozel.moviedb.dagger.modules.ApplicationModule;
 import com.halil.ozel.moviedb.dagger.modules.HttpClientModule;
 import com.halil.ozel.moviedb.ui.detail.adapters.MovieCastAdapter;
 import com.halil.ozel.moviedb.ui.detail.MovieDetailActivity;
+import com.halil.ozel.moviedb.ui.detail.CastDetailActivity;
 import com.halil.ozel.moviedb.ui.detail.adapters.RecommendMovieAdapter;
 import com.halil.ozel.moviedb.ui.home.activity.MainActivity;
 
@@ -28,6 +29,8 @@ public interface ApplicationComponent {
     void inject(MainActivity mainActivity);
 
     void inject(MovieDetailActivity movieDetailActivity);
+
+    void inject(CastDetailActivity castDetailActivity);
 
     void inject(MovieAdapter movieAdapter);
 

--- a/app/src/main/java/com/halil/ozel/moviedb/dagger/modules/HttpClientModule.java
+++ b/app/src/main/java/com/halil/ozel/moviedb/dagger/modules/HttpClientModule.java
@@ -27,6 +27,7 @@ public class HttpClientModule {
     public static final String TOP_RATED = "movie/top_rated";
     public static final String UPCOMING = "movie/upcoming";
     public static final String MOVIE_DETAILS = "movie/";
+    public static final String PERSON_DETAILS = "person/";
 
 
     @Provides

--- a/app/src/main/java/com/halil/ozel/moviedb/data/Api/TMDbAPI.java
+++ b/app/src/main/java/com/halil/ozel/moviedb/data/Api/TMDbAPI.java
@@ -5,6 +5,7 @@ import com.halil.ozel.moviedb.dagger.modules.HttpClientModule;
 import com.halil.ozel.moviedb.data.models.ResponseCreditDetail;
 import com.halil.ozel.moviedb.data.models.ResponseMovieDetail;
 import com.halil.ozel.moviedb.data.models.ResponseNowPlaying;
+import com.halil.ozel.moviedb.data.models.PersonDetail;
 
 import retrofit2.http.GET;
 import retrofit2.http.Path;
@@ -58,6 +59,12 @@ public interface TMDbAPI {
     @GET(HttpClientModule.MOVIE_DETAILS + "{movie_id}/recommendations")
     Observable<ResponseNowPlaying> getRecommendDetail(
             @Path("movie_id") int movie_id,
+            @Query("api_key") String api_key
+    );
+
+    @GET(HttpClientModule.PERSON_DETAILS + "{person_id}")
+    Observable<PersonDetail> getPersonDetail(
+            @Path("person_id") int person_id,
             @Query("api_key") String api_key
     );
 }

--- a/app/src/main/java/com/halil/ozel/moviedb/data/models/PersonDetail.java
+++ b/app/src/main/java/com/halil/ozel/moviedb/data/models/PersonDetail.java
@@ -1,0 +1,52 @@
+package com.halil.ozel.moviedb.data.models;
+
+import java.io.Serializable;
+
+public class PersonDetail implements Serializable {
+
+    private Integer id;
+    private String name;
+    private String biography;
+    private String birthday;
+    private String profile_path;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getBiography() {
+        return biography;
+    }
+
+    public void setBiography(String biography) {
+        this.biography = biography;
+    }
+
+    public String getBirthday() {
+        return birthday;
+    }
+
+    public void setBirthday(String birthday) {
+        this.birthday = birthday;
+    }
+
+    public String getProfile_path() {
+        return profile_path;
+    }
+
+    public void setProfile_path(String profile_path) {
+        this.profile_path = profile_path;
+    }
+}

--- a/app/src/main/java/com/halil/ozel/moviedb/ui/detail/CastDetailActivity.java
+++ b/app/src/main/java/com/halil/ozel/moviedb/ui/detail/CastDetailActivity.java
@@ -1,0 +1,70 @@
+package com.halil.ozel.moviedb.ui.detail;
+
+import static com.halil.ozel.moviedb.data.Api.TMDbAPI.IMAGE_BASE_URL_500;
+import static com.halil.ozel.moviedb.data.Api.TMDbAPI.TMDb_API_KEY;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.widget.ImageView;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import com.halil.ozel.moviedb.App;
+import com.halil.ozel.moviedb.R;
+import com.halil.ozel.moviedb.data.Api.TMDbAPI;
+import com.halil.ozel.moviedb.data.models.PersonDetail;
+import com.squareup.picasso.Picasso;
+
+import javax.inject.Inject;
+
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import timber.log.Timber;
+
+public class CastDetailActivity extends Activity {
+
+    @Inject
+    TMDbAPI tmDbAPI;
+
+    private ImageView ivProfile;
+    private TextView tvName;
+    private TextView tvBirthday;
+    private TextView tvBiography;
+
+    private int personId;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        App.instance().appComponent().inject(this);
+        setContentView(R.layout.activity_cast_detail);
+
+        ivProfile = findViewById(R.id.ivProfile);
+        tvName = findViewById(R.id.tvName);
+        tvBirthday = findViewById(R.id.tvBirthday);
+        tvBiography = findViewById(R.id.tvBiography);
+
+        personId = getIntent().getIntExtra("person_id", 0);
+        loadPersonDetail();
+    }
+
+    private void loadPersonDetail() {
+        tmDbAPI.getPersonDetail(personId, TMDb_API_KEY)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(this::bindPerson,
+                        e -> {
+                            Timber.e(e, "Error fetching person detail: %s", e.getMessage());
+                            Toast.makeText(this, R.string.error_loading_data, Toast.LENGTH_SHORT).show();
+                        });
+    }
+
+    private void bindPerson(PersonDetail detail) {
+        tvName.setText(detail.getName());
+        tvBirthday.setText(getString(R.string.birthday_format, detail.getBirthday()));
+        tvBiography.setText(detail.getBiography());
+        if (detail.getProfile_path() != null) {
+            Picasso.get().load(IMAGE_BASE_URL_500 + detail.getProfile_path()).into(ivProfile);
+        }
+    }
+}

--- a/app/src/main/java/com/halil/ozel/moviedb/ui/detail/adapters/MovieCastAdapter.java
+++ b/app/src/main/java/com/halil/ozel/moviedb/ui/detail/adapters/MovieCastAdapter.java
@@ -6,6 +6,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
+import android.content.Intent;
 
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
@@ -14,6 +15,7 @@ import com.halil.ozel.moviedb.App;
 import com.halil.ozel.moviedb.R;
 import com.halil.ozel.moviedb.data.Api.TMDbAPI;
 import com.halil.ozel.moviedb.data.models.Cast;
+import com.halil.ozel.moviedb.ui.detail.CastDetailActivity;
 import com.squareup.picasso.Picasso;
 
 import java.util.List;
@@ -60,6 +62,12 @@ public class MovieCastAdapter extends RecyclerView.Adapter<MovieCastAdapter.Movi
                     load("https://www.salonlfc.com/wp-content/uploads/2018/01/image-not-found-scaled-1150x647.png")
                     .into(holder.ivCastPoster);
         }
+
+        holder.itemView.setOnClickListener(v -> {
+            Intent intent = new Intent(context, CastDetailActivity.class);
+            intent.putExtra("person_id", cast.getId());
+            context.startActivity(intent);
+        });
     }
 
 

--- a/app/src/main/res/layout/activity_cast_detail.xml
+++ b/app/src/main/res/layout/activity_cast_detail.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp">
+
+        <ImageView
+            android:id="@+id/ivProfile"
+            android:layout_width="match_parent"
+            android:layout_height="300dp"
+            android:scaleType="centerCrop" />
+
+        <TextView
+            android:id="@+id/tvName"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:textSize="20sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/tvBirthday"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp" />
+
+        <TextView
+            android:id="@+id/tvBiography"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp" />
+
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -6,6 +6,14 @@
     android:layout_height="match_parent"
     tools:context=".ui.home.activity.MainActivity">
 
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorPrimary"
+        android:titleTextColor="@android:color/white"
+        android:title="@string/app_name" />
+
 
     <LinearLayout
         android:orientation="vertical"

--- a/app/src/main/res/layout/activity_movie_detail.xml
+++ b/app/src/main/res/layout/activity_movie_detail.xml
@@ -9,10 +9,19 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/detailToolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorPrimary"
+        android:titleTextColor="@android:color/white"
+        android:title="@string/app_name" />
+
     <androidx.core.widget.NestedScrollView
         android:id="@+id/svDetail"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:layout_below="@id/detailToolbar">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,5 @@
 <resources>
     <string name="app_name">Movie DB</string>
+    <string name="error_loading_data">Error loading data</string>
+    <string name="birthday_format">Birthday : %1$s</string>
 </resources>


### PR DESCRIPTION
## Summary
- add MaterialToolbars on main and detail screens for modern look
- open cast detail screen when a cast item is tapped
- support new TMDb API person endpoint
- show basic cast info in new CastDetailActivity

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6856be836d30832bb01a84f6221002ec