### PR TITLE
Fix missing closing tag in movies fragment

### DIFF
--- a/app/src/main/res/layout/fragment_movies.xml
+++ b/app/src/main/res/layout/fragment_movies.xml
@@ -82,4 +82,5 @@
 
     </LinearLayout>
 
+</LinearLayout>
 </androidx.core.widget.NestedScrollView>


### PR DESCRIPTION
## Summary
- fix layout crash by closing the outer `LinearLayout` in `fragment_movies.xml`

## Testing
- `./gradlew test --dry-run` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6856cb422f4c832ba5edcbfff7e9637a