### PR TITLE
Add TV series detail screen and UI tweaks

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,8 @@
             />
         <activity android:name=".ui.detail.CastDetailActivity"
             android:screenOrientation="portrait" />
+        <activity android:name=".ui.detail.TvSeriesDetailActivity"
+            android:screenOrientation="portrait" />
         <activity
             android:exported="true"
             android:name=".ui.splash.SplashActivity">

--- a/app/src/main/java/com/halil/ozel/moviedb/dagger/components/ApplicationComponent.java
+++ b/app/src/main/java/com/halil/ozel/moviedb/dagger/components/ApplicationComponent.java
@@ -8,6 +8,7 @@ import com.halil.ozel.moviedb.dagger.modules.HttpClientModule;
 import com.halil.ozel.moviedb.ui.detail.adapters.MovieCastAdapter;
 import com.halil.ozel.moviedb.ui.detail.MovieDetailActivity;
 import com.halil.ozel.moviedb.ui.detail.CastDetailActivity;
+import com.halil.ozel.moviedb.ui.detail.TvSeriesDetailActivity;
 import com.halil.ozel.moviedb.ui.detail.adapters.RecommendMovieAdapter;
 import com.halil.ozel.moviedb.ui.home.activity.MainActivity;
 import com.halil.ozel.moviedb.ui.home.fragments.MoviesFragment;
@@ -34,6 +35,7 @@ public interface ApplicationComponent {
     void inject(MainActivity mainActivity);
 
     void inject(MovieDetailActivity movieDetailActivity);
+    void inject(TvSeriesDetailActivity tvSeriesDetailActivity);
 
     void inject(CastDetailActivity castDetailActivity);
 

--- a/app/src/main/java/com/halil/ozel/moviedb/dagger/modules/HttpClientModule.java
+++ b/app/src/main/java/com/halil/ozel/moviedb/dagger/modules/HttpClientModule.java
@@ -30,6 +30,7 @@ public class HttpClientModule {
     public static final String TV_AIRING_TODAY = "tv/airing_today";
     public static final String TV_ON_THE_AIR = "tv/on_the_air";
     public static final String TV_POPULAR = "tv/popular";
+    public static final String TV_DETAILS = "tv/";
     public static final String GENRE_MOVIE = "genre/movie/list";
     public static final String GENRE_TV = "genre/tv/list";
     public static final String SEARCH_KEYWORD = "search/keyword";

--- a/app/src/main/java/com/halil/ozel/moviedb/data/Api/TMDbAPI.java
+++ b/app/src/main/java/com/halil/ozel/moviedb/data/Api/TMDbAPI.java
@@ -70,6 +70,24 @@ public interface TMDbAPI {
             @Query("page") int page
     );
 
+    @GET(HttpClientModule.TV_DETAILS + "{tv_id}")
+    Observable<ResponseTvSeriesDetail> getTvSeriesDetail(
+            @Path("tv_id") int tvId,
+            @Query("api_key") String api_key
+    );
+
+    @GET(HttpClientModule.TV_DETAILS + "{tv_id}/credits")
+    Observable<ResponseCreditDetail> getTvCastDetail(
+            @Path("tv_id") int tvId,
+            @Query("api_key") String api_key
+    );
+
+    @GET(HttpClientModule.TV_DETAILS + "{tv_id}/recommendations")
+    Observable<ResponseTvSeries> getTvRecommendations(
+            @Path("tv_id") int tvId,
+            @Query("api_key") String api_key
+    );
+
     @GET(HttpClientModule.GENRE_MOVIE)
     Observable<ResponseGenreList> getMovieGenres(
             @Query("api_key") String api_key

--- a/app/src/main/java/com/halil/ozel/moviedb/data/models/ResponseTvSeriesDetail.java
+++ b/app/src/main/java/com/halil/ozel/moviedb/data/models/ResponseTvSeriesDetail.java
@@ -1,0 +1,61 @@
+package com.halil.ozel.moviedb.data.models;
+
+import java.io.Serializable;
+import java.util.List;
+
+public class ResponseTvSeriesDetail implements Serializable {
+    private List<Genres> genres;
+    private Integer id;
+    private String first_air_date;
+    private String popularity;
+    private String overview;
+    private String backdrop_path;
+
+    public List<Genres> getGenres() {
+        return genres;
+    }
+
+    public void setGenres(List<Genres> genres) {
+        this.genres = genres;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getFirst_air_date() {
+        return first_air_date;
+    }
+
+    public void setFirst_air_date(String first_air_date) {
+        this.first_air_date = first_air_date;
+    }
+
+    public String getPopularity() {
+        return popularity;
+    }
+
+    public void setPopularity(String popularity) {
+        this.popularity = popularity;
+    }
+
+    public String getOverview() {
+        return overview;
+    }
+
+    public void setOverview(String overview) {
+        this.overview = overview;
+    }
+
+    public String getBackdrop_path() {
+        return backdrop_path;
+    }
+
+    public void setBackdrop_path(String backdrop_path) {
+        this.backdrop_path = backdrop_path;
+    }
+}

--- a/app/src/main/java/com/halil/ozel/moviedb/ui/detail/TvSeriesDetailActivity.java
+++ b/app/src/main/java/com/halil/ozel/moviedb/ui/detail/TvSeriesDetailActivity.java
@@ -1,0 +1,186 @@
+package com.halil.ozel.moviedb.ui.detail;
+
+import static com.halil.ozel.moviedb.data.Api.TMDbAPI.IMAGE_BASE_URL_1280;
+import static com.halil.ozel.moviedb.data.Api.TMDbAPI.IMAGE_BASE_URL_500;
+import static com.halil.ozel.moviedb.data.Api.TMDbAPI.TMDb_API_KEY;
+
+import android.annotation.SuppressLint;
+import android.app.Activity;
+import android.os.Bundle;
+import android.view.animation.OvershootInterpolator;
+import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.halil.ozel.moviedb.App;
+import com.halil.ozel.moviedb.R;
+import com.halil.ozel.moviedb.data.Api.TMDbAPI;
+import com.halil.ozel.moviedb.data.models.Cast;
+import com.halil.ozel.moviedb.data.models.Genres;
+import com.halil.ozel.moviedb.data.models.TvResults;
+import com.halil.ozel.moviedb.data.models.Results;
+import com.halil.ozel.moviedb.data.FavoritesManager;
+import com.halil.ozel.moviedb.ui.detail.adapters.MovieCastAdapter;
+import com.halil.ozel.moviedb.ui.home.adapters.TvSeriesAdapter;
+import com.squareup.picasso.Picasso;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import at.blogc.android.views.ExpandableTextView;
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import timber.log.Timber;
+
+public class TvSeriesDetailActivity extends Activity {
+
+    String title;
+    int id;
+    ImageView ivHorizontalPoster, ivVerticalPoster;
+    TextView tvTitle, tvGenres, tvPopularity, tvReleaseDate;
+    ExpandableTextView etvOverview;
+    Button btnToggle;
+    com.google.android.material.floatingactionbutton.FloatingActionButton fabFavorite;
+
+    @Inject
+    TMDbAPI tmDbAPI;
+
+    public RecyclerView rvCast, rvRecommendContents;
+    public RecyclerView.Adapter castAdapter, recommendAdapter;
+    public RecyclerView.LayoutManager castLayoutManager, recommendLayoutManager;
+    public List<Cast> castDataList;
+    public List<TvResults> recommendDataList;
+
+    @SuppressLint("SetTextI18n")
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        App.instance().appComponent().inject(this);
+        setContentView(R.layout.activity_tv_series_detail);
+
+        ivVerticalPoster = findViewById(R.id.ivVerticalPoster);
+        ivHorizontalPoster = findViewById(R.id.ivHorizontalPoster);
+        tvTitle = findViewById(R.id.tvTitle);
+        tvGenres = findViewById(R.id.tvGenres);
+        tvPopularity = findViewById(R.id.tvPopularity);
+        tvReleaseDate = findViewById(R.id.tvReleaseDate);
+        etvOverview = findViewById(R.id.etvOverview);
+        btnToggle = findViewById(R.id.btnToggle);
+        fabFavorite = findViewById(R.id.fabFavorite);
+
+        castDataList = new ArrayList<>();
+        castAdapter = new MovieCastAdapter(castDataList, this);
+        castLayoutManager = new LinearLayoutManager(this, LinearLayoutManager.HORIZONTAL, false);
+
+        rvCast = findViewById(R.id.rvCast);
+        rvCast.setHasFixedSize(true);
+        rvCast.setLayoutManager(castLayoutManager);
+        rvCast.setAdapter(castAdapter);
+
+        recommendDataList = new ArrayList<>();
+        recommendAdapter = new TvSeriesAdapter(recommendDataList, this);
+        recommendLayoutManager = new LinearLayoutManager(this, LinearLayoutManager.HORIZONTAL, false);
+
+        rvRecommendContents = findViewById(R.id.rvRecommendContents);
+        rvRecommendContents.setHasFixedSize(true);
+        rvRecommendContents.setLayoutManager(recommendLayoutManager);
+        rvRecommendContents.setAdapter(recommendAdapter);
+
+        etvOverview.setAnimationDuration(750L);
+        etvOverview.setInterpolator(new OvershootInterpolator());
+        etvOverview.setExpandInterpolator(new OvershootInterpolator());
+        etvOverview.setCollapseInterpolator(new OvershootInterpolator());
+
+        btnToggle.setOnClickListener(v -> {
+            if (etvOverview.isExpanded()) {
+                etvOverview.collapse();
+                btnToggle.setBackgroundResource(R.drawable.ic_expand_more);
+            } else {
+                etvOverview.expand();
+                btnToggle.setBackgroundResource(R.drawable.ic_expand_less);
+            }
+        });
+
+        title = getIntent().getStringExtra("title");
+        id = getIntent().getIntExtra("id", 0);
+        tvTitle.setText(title);
+        etvOverview.setText(getIntent().getStringExtra("overview"));
+        tvPopularity.setText("Popularity : " + getIntent().getDoubleExtra("popularity", 0));
+        tvReleaseDate.setText("First Air Date : " + getIntent().getStringExtra("release_date"));
+
+        Picasso.get().load(IMAGE_BASE_URL_1280 + getIntent().getStringExtra("backdrop")).into(ivHorizontalPoster);
+        Picasso.get().load(IMAGE_BASE_URL_500 + getIntent().getStringExtra("poster")).into(ivVerticalPoster);
+
+        List<Genres> labelPS = (List<Genres>) getIntent().getSerializableExtra("genres");
+        if (labelPS != null && !labelPS.isEmpty()) {
+            StringBuilder genres = new StringBuilder();
+            for (int i = 0; i < labelPS.size(); i++) {
+                if (labelPS.get(i) == null) continue;
+                if (i == labelPS.size() - 1) {
+                    genres.append(labelPS.get(i).getName());
+                } else {
+                    genres.append(labelPS.get(i).getName()).append(" | ");
+                }
+            }
+            tvGenres.setText(genres.toString());
+        } else {
+            tvGenres.setText("");
+        }
+
+        getCastInfo();
+        getRecommendTv();
+
+        updateFab();
+        fabFavorite.setOnClickListener(v -> {
+            if (FavoritesManager.isFavorite(this, id)) {
+                FavoritesManager.remove(this, id);
+            } else {
+                TvResults r = new TvResults();
+                r.setId(id);
+                r.setName(title);
+                r.setPoster_path(getIntent().getStringExtra("poster"));
+                FavoritesManager.add(this, convert(r));
+            }
+            updateFab();
+        });
+    }
+
+    private Results convert(TvResults tv) {
+        Results r = new Results();
+        r.setId(tv.getId());
+        r.setTitle(tv.getName());
+        r.setPoster_path(tv.getPoster_path());
+        return r;
+    }
+
+    @SuppressLint("NotifyDataSetChanged")
+    public void getCastInfo() {
+        tmDbAPI.getTvCastDetail(id, TMDb_API_KEY).subscribeOn(Schedulers.io()).observeOn(AndroidSchedulers.mainThread()).subscribe(response -> {
+            castDataList.addAll(response.getCast());
+            castAdapter.notifyDataSetChanged();
+
+        }, e -> Timber.e(e, "Error fetching tv cast: %s", e.getMessage()));
+    }
+
+    @SuppressLint("NotifyDataSetChanged")
+    public void getRecommendTv() {
+        tmDbAPI.getTvRecommendations(id, TMDb_API_KEY).subscribeOn(Schedulers.io()).observeOn(AndroidSchedulers.mainThread()).subscribe(response -> {
+            recommendDataList.addAll(response.getResults());
+            recommendAdapter.notifyDataSetChanged();
+
+        }, e -> Timber.e(e, "Error fetching tv recommendations: %s", e.getMessage()));
+    }
+
+    private void updateFab() {
+        if (FavoritesManager.isFavorite(this, id)) {
+            fabFavorite.setImageResource(android.R.drawable.btn_star_big_on);
+        } else {
+            fabFavorite.setImageResource(android.R.drawable.btn_star_big_off);
+        }
+    }
+}

--- a/app/src/main/java/com/halil/ozel/moviedb/ui/home/adapters/TvSeriesAdapter.java
+++ b/app/src/main/java/com/halil/ozel/moviedb/ui/home/adapters/TvSeriesAdapter.java
@@ -4,7 +4,9 @@ import android.content.Context;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.content.Intent;
 import android.widget.ImageView;
+import android.widget.ImageButton;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
@@ -14,6 +16,10 @@ import com.halil.ozel.moviedb.App;
 import com.halil.ozel.moviedb.R;
 import com.halil.ozel.moviedb.data.Api.TMDbAPI;
 import com.halil.ozel.moviedb.data.models.TvResults;
+import com.halil.ozel.moviedb.data.models.Results;
+import com.halil.ozel.moviedb.data.models.ResponseTvSeriesDetail;
+import com.halil.ozel.moviedb.data.FavoritesManager;
+import com.halil.ozel.moviedb.ui.detail.TvSeriesDetailActivity;
 import com.squareup.picasso.Picasso;
 
 import java.util.List;
@@ -21,6 +27,11 @@ import java.util.List;
 import javax.inject.Inject;
 
 import static com.halil.ozel.moviedb.data.Api.TMDbAPI.IMAGE_BASE_URL_500;
+import static com.halil.ozel.moviedb.data.Api.TMDbAPI.TMDb_API_KEY;
+
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import timber.log.Timber;
 
 public class TvSeriesAdapter extends RecyclerView.Adapter<TvSeriesAdapter.TvSeriesHolder> {
 
@@ -47,6 +58,43 @@ public class TvSeriesAdapter extends RecyclerView.Adapter<TvSeriesAdapter.TvSeri
         TvResults tv = tvList.get(position);
         holder.title.setText(tv.getName());
         Picasso.get().load(IMAGE_BASE_URL_500 + tv.getPoster_path()).into(holder.poster);
+
+        boolean fav = FavoritesManager.isFavorite(context, tv.getId());
+        holder.btnFavorite.setImageResource(fav ? android.R.drawable.btn_star_big_on : android.R.drawable.btn_star_big_off);
+
+        holder.btnFavorite.setOnClickListener(v -> {
+            if (FavoritesManager.isFavorite(context, tv.getId())) {
+                FavoritesManager.remove(context, tv.getId());
+                holder.btnFavorite.setImageResource(android.R.drawable.btn_star_big_off);
+            } else {
+                FavoritesManager.add(context, convert(tv));
+                holder.btnFavorite.setImageResource(android.R.drawable.btn_star_big_on);
+            }
+        });
+
+        holder.itemView.setOnClickListener(view -> tmDbAPI.getTvSeriesDetail(tv.getId(), TMDb_API_KEY)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(response -> {
+                    Intent intent = new Intent(view.getContext(), TvSeriesDetailActivity.class);
+                    intent.putExtra("id", tv.getId());
+                    intent.putExtra("title", tv.getName());
+                    intent.putExtra("backdrop", "");
+                    intent.putExtra("poster", tv.getPoster_path());
+                    intent.putExtra("overview", response instanceof ResponseTvSeriesDetail ? ((ResponseTvSeriesDetail) response).getOverview() : "");
+                    intent.putExtra("popularity", response.getPopularity());
+                    intent.putExtra("release_date", response.getFirst_air_date());
+                    intent.putExtra("genres", (java.io.Serializable) response.getGenres());
+                    view.getContext().startActivity(intent);
+                }, e -> Timber.e(e, "Error fetching tv detail: %s", e.getMessage())));
+    }
+
+    private Results convert(TvResults tv) {
+        Results r = new Results();
+        r.setId(tv.getId());
+        r.setTitle(tv.getName());
+        r.setPoster_path(tv.getPoster_path());
+        return r;
     }
 
     @Override
@@ -57,10 +105,12 @@ public class TvSeriesAdapter extends RecyclerView.Adapter<TvSeriesAdapter.TvSeri
     static class TvSeriesHolder extends RecyclerView.ViewHolder {
         TextView title;
         ImageView poster;
+        ImageButton btnFavorite;
         TvSeriesHolder(View itemView) {
             super(itemView);
             title = itemView.findViewById(R.id.tvPopularMovieTitle);
             poster = itemView.findViewById(R.id.ivPopularPoster);
+            btnFavorite = itemView.findViewById(R.id.btnFavorite);
         }
     }
 }

--- a/app/src/main/java/com/halil/ozel/moviedb/ui/home/fragments/FavoriteFragment.java
+++ b/app/src/main/java/com/halil/ozel/moviedb/ui/home/fragments/FavoriteFragment.java
@@ -8,7 +8,7 @@ import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
-import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.halil.ozel.moviedb.R;
@@ -28,7 +28,7 @@ public class FavoriteFragment extends Fragment {
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_favorite, container, false);
         recyclerView = view.findViewById(R.id.rvFavorites);
-        recyclerView.setLayoutManager(new LinearLayoutManager(getContext(), LinearLayoutManager.VERTICAL, false));
+        recyclerView.setLayoutManager(new GridLayoutManager(getContext(), 3));
         recyclerView.setNestedScrollingEnabled(false);
 
         loadData();

--- a/app/src/main/res/layout/activity_cast_detail.xml
+++ b/app/src/main/res/layout/activity_cast_detail.xml
@@ -13,7 +13,7 @@
             android:id="@+id/ivProfile"
             android:layout_width="match_parent"
             android:layout_height="300dp"
-            android:scaleType="centerCrop"
+            android:scaleType="fitCenter"
             android:adjustViewBounds="true" />
 
         <TextView

--- a/app/src/main/res/layout/activity_tv_series_detail.xml
+++ b/app/src/main/res/layout/activity_tv_series_detail.xml
@@ -1,0 +1,236 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/rlRootDetail"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/detailToolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorPrimary"
+        android:titleTextColor="@android:color/white"
+        android:title="@string/app_name" />
+
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/svDetail"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_below="@id/detailToolbar">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+
+            <LinearLayout
+                android:id="@+id/llOverview"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_marginTop="17dp"
+                android:orientation="vertical"
+                app:layout_constraintTop_toBottomOf="@+id/llInfo"
+                tools:layout_editor_absoluteX="0dp">
+
+                <at.blogc.android.views.ExpandableTextView
+                    android:layout_margin="4dp"
+                    android:id="@+id/etvOverview"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:maxLines="4"
+                    android:paddingStart="5dp"
+                    android:textColor="#ffffff"
+                    app:animation_duration="750">
+
+
+                </at.blogc.android.views.ExpandableTextView>
+
+                <Button
+                    android:id="@+id/btnToggle"
+                    android:layout_width="36dp"
+                    android:layout_height="36dp"
+                    android:layout_gravity="end"
+                    android:background="@drawable/ic_expand_more" />
+
+            </LinearLayout>
+
+
+            <LinearLayout
+                android:id="@+id/linearLayout2"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="vertical">
+
+                <ImageView
+                    android:id="@+id/ivHorizontalPoster"
+                    android:layout_width="match_parent"
+                    android:layout_height="200dp"
+                    android:foreground="@drawable/gradient"
+                    android:scaleType="fitXY" />
+            </LinearLayout>
+
+
+
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/cardView"
+                android:layout_width="wrap_content"
+                android:layout_height="150dp"
+                android:layout_marginStart="8dp"
+                android:layout_marginTop="144dp"
+                app:cardElevation="3dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/llInfo"
+                app:layout_constraintTop_toTopOf="parent">
+
+
+                <ImageView
+                    android:id="@+id/ivVerticalPoster"
+                    android:layout_width="100dp"
+                    android:layout_height="150dp"
+                    android:scaleType="fitXY" />
+
+
+            </com.google.android.material.card.MaterialCardView>
+
+
+            <LinearLayout
+                android:id="@+id/llInfo"
+                android:layout_width="280dp"
+                android:layout_height="match_parent"
+                android:layout_marginTop="8dp"
+                android:orientation="vertical"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/linearLayout2">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
+
+                    <TextView
+                        android:id="@+id/tvTitle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="5dp"
+                        android:layout_marginRight="6dp"
+                        android:layout_marginBottom="5dp"
+                        android:paddingStart="3dp"
+                        android:text="TextView"
+                        android:textColor="#ffffff"
+                        android:textSize="20sp"
+                        android:textStyle="bold" />
+
+
+                </LinearLayout>
+
+                <TextView
+                    android:id="@+id/tvGenres"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="3dp"
+                    android:layout_marginTop="5dp"
+                    android:layout_marginEnd="6dp"
+                    android:maxLines="3" />
+
+                <TextView
+                    android:id="@+id/tvPopularity"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="4dp"
+                    android:layout_marginTop="5dp"
+                    android:layout_marginEnd="6dp"
+                    android:maxLines="3" />
+
+                <TextView
+                    android:id="@+id/tvReleaseDate"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="4dp"
+                    android:layout_marginTop="5dp"
+                    android:layout_marginEnd="4dp"
+                    android:maxLines="3" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/ll4"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:layout_marginBottom="45dp"
+                android:orientation="vertical"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/llOverview">
+
+
+                <TextView
+                    android:id="@+id/tvCast"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="15dp"
+                    android:paddingStart="15dp"
+                    android:text="Full Casts"
+                    android:textSize="16sp" />
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/rvCast"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_marginStart="5dp"
+                    android:layout_marginTop="5dp"
+                    android:layout_marginEnd="5dp">
+
+                </androidx.recyclerview.widget.RecyclerView>
+
+
+
+
+                <TextView
+                    android:id="@+id/tvRelated"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="15dp"
+                    android:paddingStart="15dp"
+                    android:text="Recommend Contents"
+                    android:textSize="16sp" />
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/rvRecommendContents"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_marginStart="5dp"
+                    android:layout_marginTop="5dp"
+                    android:layout_marginEnd="5dp">
+
+                </androidx.recyclerview.widget.RecyclerView>
+
+
+            </LinearLayout>
+
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+    </androidx.core.widget.NestedScrollView>
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fabFavorite"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentEnd="true"
+        android:layout_margin="16dp"
+        android:src="@android:drawable/btn_star_big_off" />
+
+
+
+
+</RelativeLayout>


### PR DESCRIPTION
## Summary
- support TV series details via new API endpoints
- add `TvSeriesDetailActivity` with corresponding layout
- implement star toggle and detail navigation in `TvSeriesAdapter`
- show favorites with grid layout
- fix cast detail photo scaling
- register new activity in manifest

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6856cf11e068832b8f5a5e96d7b59d8a