### PR TITLE
Fix detail page text color for light theme

### DIFF
--- a/app/src/main/res/layout/activity_movie_detail.xml
+++ b/app/src/main/res/layout/activity_movie_detail.xml
@@ -44,7 +44,7 @@
                     android:layout_height="wrap_content"
                     android:maxLines="4"
                     android:paddingStart="5dp"
-                    android:textColor="#ffffff"
+                    android:textColor="?android:textColorPrimary"
                     app:animation_duration="750">
 
 
@@ -122,7 +122,7 @@
                         android:layout_marginBottom="5dp"
                         android:paddingStart="3dp"
                         android:text="TextView"
-                        android:textColor="#ffffff"
+                        android:textColor="?android:textColorPrimary"
                         android:textSize="20sp"
                         android:textStyle="bold" />
 

--- a/app/src/main/res/layout/activity_tv_series_detail.xml
+++ b/app/src/main/res/layout/activity_tv_series_detail.xml
@@ -44,7 +44,7 @@
                     android:layout_height="wrap_content"
                     android:maxLines="4"
                     android:paddingStart="5dp"
-                    android:textColor="#ffffff"
+                    android:textColor="?android:textColorPrimary"
                     app:animation_duration="750">
 
 
@@ -122,7 +122,7 @@
                         android:layout_marginBottom="5dp"
                         android:paddingStart="3dp"
                         android:text="TextView"
-                        android:textColor="#ffffff"
+                        android:textColor="?android:textColorPrimary"
                         android:textSize="20sp"
                         android:textStyle="bold" />
 


### PR DESCRIPTION
## Summary
- use theme text color for overview and title text on detail pages so light mode works correctly

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6856d7d2058c832b8d33990af3899b44