### PR TITLE
Improve detail screens with emoji and feedback

### DIFF
--- a/app/src/main/java/com/halil/ozel/moviedb/ui/detail/MovieDetailActivity.java
+++ b/app/src/main/java/com/halil/ozel/moviedb/ui/detail/MovieDetailActivity.java
@@ -12,6 +12,7 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -117,8 +118,10 @@ public class MovieDetailActivity extends Activity {
         title = getIntent().getStringExtra("title");
         id = getIntent().getIntExtra("id", 0);
         tvTitle.setText(title);
-        tvPopularity.setText("Popularity : " + getIntent().getDoubleExtra("popularity", 0));
-        tvReleaseDate.setText("Release Date : " + getIntent().getStringExtra("release_date"));
+        tvPopularity.setText(getString(R.string.popularity_format,
+                getIntent().getDoubleExtra("popularity", 0)));
+        tvReleaseDate.setText(getString(R.string.release_date_format,
+                getIntent().getStringExtra("release_date")));
 
         Picasso.get().load(IMAGE_BASE_URL_1280 + getIntent().getStringExtra("backdrop")).into(ivHorizontalPoster);
         Picasso.get().load(IMAGE_BASE_URL_500 + getIntent().getStringExtra("poster")).into(ivVerticalPoster);
@@ -135,7 +138,7 @@ public class MovieDetailActivity extends Activity {
                     genres = genres.concat(labelPS.get(i).getName() + " | ");
                 }
             }
-            tvGenres.setText(genres);
+            tvGenres.setText("\uD83C\uDFAD " + genres);
         } else {
             tvGenres.setText("");
         }
@@ -147,6 +150,7 @@ public class MovieDetailActivity extends Activity {
             if (FavoritesManager.isFavorite(this, id)) {
                 FavoritesManager.remove(this, id);
                 fabFavorite.setImageResource(android.R.drawable.btn_star_big_off);
+                Toast.makeText(this, R.string.favorite_removed, Toast.LENGTH_SHORT).show();
             } else {
                 Results r = new Results();
                 r.setId(id);
@@ -158,7 +162,9 @@ public class MovieDetailActivity extends Activity {
                 r.setRelease_date(getIntent().getStringExtra("release_date"));
                 FavoritesManager.add(this, r);
                 fabFavorite.setImageResource(android.R.drawable.btn_star_big_on);
+                Toast.makeText(this, R.string.favorite_added, Toast.LENGTH_SHORT).show();
             }
+            updateFab();
         });
     }
 

--- a/app/src/main/java/com/halil/ozel/moviedb/ui/detail/TvSeriesDetailActivity.java
+++ b/app/src/main/java/com/halil/ozel/moviedb/ui/detail/TvSeriesDetailActivity.java
@@ -12,6 +12,7 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -112,8 +113,10 @@ public class TvSeriesDetailActivity extends Activity {
         id = getIntent().getIntExtra("id", 0);
         tvTitle.setText(title);
         etvOverview.setText(getIntent().getStringExtra("overview"));
-        tvPopularity.setText("Popularity : " + getIntent().getDoubleExtra("popularity", 0));
-        tvReleaseDate.setText("First Air Date : " + getIntent().getStringExtra("release_date"));
+        tvPopularity.setText(getString(R.string.popularity_format,
+                getIntent().getDoubleExtra("popularity", 0)));
+        tvReleaseDate.setText(getString(R.string.first_air_date_format,
+                getIntent().getStringExtra("release_date")));
 
         Picasso.get().load(IMAGE_BASE_URL_1280 + getIntent().getStringExtra("backdrop")).into(ivHorizontalPoster);
         Picasso.get().load(IMAGE_BASE_URL_500 + getIntent().getStringExtra("poster")).into(ivVerticalPoster);
@@ -129,7 +132,7 @@ public class TvSeriesDetailActivity extends Activity {
                     genres.append(labelPS.get(i).getName()).append(" | ");
                 }
             }
-            tvGenres.setText(genres.toString());
+            tvGenres.setText("\uD83C\uDFAD " + genres.toString());
         } else {
             tvGenres.setText("");
         }
@@ -142,6 +145,7 @@ public class TvSeriesDetailActivity extends Activity {
             if (FavoritesManager.isFavorite(this, id)) {
                 FavoritesManager.remove(this, id);
                 fabFavorite.setImageResource(android.R.drawable.btn_star_big_off);
+                Toast.makeText(this, R.string.favorite_removed, Toast.LENGTH_SHORT).show();
             } else {
                 TvResults r = new TvResults();
                 r.setId(id);
@@ -149,7 +153,9 @@ public class TvSeriesDetailActivity extends Activity {
                 r.setPoster_path(getIntent().getStringExtra("poster"));
                 FavoritesManager.add(this, convert(r));
                 fabFavorite.setImageResource(android.R.drawable.btn_star_big_on);
+                Toast.makeText(this, R.string.favorite_added, Toast.LENGTH_SHORT).show();
             }
+            updateFab();
         });
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,10 @@
 <resources>
     <string name="app_name">Movie DB</string>
     <string name="error_loading_data">Error loading data</string>
-    <string name="birthday_format">Birthday : %1$s</string>
+    <string name="birthday_format">🎂 Birthday : %1$s</string>
+    <string name="popularity_format">🔥 Popularity : %1$.1f</string>
+    <string name="release_date_format">📅 Release Date : %1$s</string>
+    <string name="first_air_date_format">📅 First Air Date : %1$s</string>
+    <string name="favorite_added">Added to favorites</string>
+    <string name="favorite_removed">Removed from favorites</string>
 </resources>


### PR DESCRIPTION
## Summary
- add emoji strings for date and popularity
- show toasts when toggling favorites
- decorate genre text with emoji

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6856db21e82c832b91e28035f551e0ac