### PR TITLE
Fix search and detail UI

### DIFF
--- a/app/src/main/java/com/halil/ozel/moviedb/ui/detail/MovieDetailActivity.java
+++ b/app/src/main/java/com/halil/ozel/moviedb/ui/detail/MovieDetailActivity.java
@@ -11,11 +11,13 @@ import android.view.animation.OvershootInterpolator;
 import android.view.View;
 import android.widget.Button;
 import android.widget.ImageView;
+import android.widget.ImageButton;
 import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
+import com.google.android.material.appbar.MaterialToolbar;
 
 import com.halil.ozel.moviedb.App;
 import com.halil.ozel.moviedb.R;
@@ -46,7 +48,8 @@ public class MovieDetailActivity extends Activity {
     TextView tvTitle, tvGenres, tvPopularity, tvReleaseDate, tvRelated;
     ExpandableTextView etvOverview;
     Button btnToggle;
-    com.google.android.material.floatingactionbutton.FloatingActionButton fabFavorite;
+    ImageButton fabFavorite;
+    MaterialToolbar detailToolbar;
 
     @Inject
     TMDbAPI tmDbAPI;
@@ -74,6 +77,7 @@ public class MovieDetailActivity extends Activity {
         etvOverview = findViewById(R.id.etvOverview);
         btnToggle = findViewById(R.id.btnToggle);
         fabFavorite = findViewById(R.id.fabFavorite);
+        detailToolbar = findViewById(R.id.detailToolbar);
 
         castDataList = new ArrayList<>();
         castAdapter = new MovieCastAdapter(castDataList, this);
@@ -118,6 +122,7 @@ public class MovieDetailActivity extends Activity {
         title = getIntent().getStringExtra("title");
         id = getIntent().getIntExtra("id", 0);
         tvTitle.setText(title);
+        detailToolbar.setTitle(title);
         tvPopularity.setText(getString(R.string.popularity_format,
                 getIntent().getDoubleExtra("popularity", 0)));
         tvReleaseDate.setText(getString(R.string.release_date_format,
@@ -164,7 +169,6 @@ public class MovieDetailActivity extends Activity {
                 fabFavorite.setImageResource(android.R.drawable.btn_star_big_on);
                 Toast.makeText(this, R.string.favorite_added, Toast.LENGTH_SHORT).show();
             }
-            updateFab();
         });
     }
 

--- a/app/src/main/java/com/halil/ozel/moviedb/ui/detail/TvSeriesDetailActivity.java
+++ b/app/src/main/java/com/halil/ozel/moviedb/ui/detail/TvSeriesDetailActivity.java
@@ -11,11 +11,13 @@ import android.view.animation.OvershootInterpolator;
 import android.view.View;
 import android.widget.Button;
 import android.widget.ImageView;
+import android.widget.ImageButton;
 import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
+import com.google.android.material.appbar.MaterialToolbar;
 
 import com.halil.ozel.moviedb.App;
 import com.halil.ozel.moviedb.R;
@@ -47,7 +49,8 @@ public class TvSeriesDetailActivity extends Activity {
     TextView tvTitle, tvGenres, tvPopularity, tvReleaseDate, tvRelated;
     ExpandableTextView etvOverview;
     Button btnToggle;
-    com.google.android.material.floatingactionbutton.FloatingActionButton fabFavorite;
+    ImageButton fabFavorite;
+    MaterialToolbar detailToolbar;
 
     @Inject
     TMDbAPI tmDbAPI;
@@ -75,6 +78,7 @@ public class TvSeriesDetailActivity extends Activity {
         etvOverview = findViewById(R.id.etvOverview);
         btnToggle = findViewById(R.id.btnToggle);
         fabFavorite = findViewById(R.id.fabFavorite);
+        detailToolbar = findViewById(R.id.detailToolbar);
 
         castDataList = new ArrayList<>();
         castAdapter = new MovieCastAdapter(castDataList, this);
@@ -112,6 +116,7 @@ public class TvSeriesDetailActivity extends Activity {
         title = getIntent().getStringExtra("title");
         id = getIntent().getIntExtra("id", 0);
         tvTitle.setText(title);
+        detailToolbar.setTitle(title);
         etvOverview.setText(getIntent().getStringExtra("overview"));
         tvPopularity.setText(getString(R.string.popularity_format,
                 getIntent().getDoubleExtra("popularity", 0)));
@@ -155,7 +160,6 @@ public class TvSeriesDetailActivity extends Activity {
                 fabFavorite.setImageResource(android.R.drawable.btn_star_big_on);
                 Toast.makeText(this, R.string.favorite_added, Toast.LENGTH_SHORT).show();
             }
-            updateFab();
         });
     }
 

--- a/app/src/main/java/com/halil/ozel/moviedb/ui/home/adapters/MovieAdapter.java
+++ b/app/src/main/java/com/halil/ozel/moviedb/ui/home/adapters/MovieAdapter.java
@@ -57,7 +57,15 @@ public class MovieAdapter extends RecyclerView.Adapter<MovieAdapter.PopularMovie
     public void onBindViewHolder(@NonNull final PopularMovieHolder holder, final int position) {
         Results results = popularMovieList.get(position);
         holder.tvPopularMovieTitle.setText(results.getTitle());
-        Picasso.get().load(IMAGE_BASE_URL_500 + results.getPoster_path()).into(holder.ivPopularPoster);
+        if (results.getPoster_path() != null) {
+            Picasso.get()
+                    .load(IMAGE_BASE_URL_500 + results.getPoster_path())
+                    .into(holder.ivPopularPoster);
+        } else {
+            Picasso.get()
+                    .load("https://www.salonlfc.com/wp-content/uploads/2018/01/image-not-found-scaled-1150x647.png")
+                    .into(holder.ivPopularPoster);
+        }
 
         boolean fav = FavoritesManager.isFavorite(context, results.getId());
         holder.btnFavorite.setImageResource(fav ? android.R.drawable.btn_star_big_on : android.R.drawable.btn_star_big_off);

--- a/app/src/main/java/com/halil/ozel/moviedb/ui/home/adapters/TvSeriesAdapter.java
+++ b/app/src/main/java/com/halil/ozel/moviedb/ui/home/adapters/TvSeriesAdapter.java
@@ -57,7 +57,15 @@ public class TvSeriesAdapter extends RecyclerView.Adapter<TvSeriesAdapter.TvSeri
     public void onBindViewHolder(@NonNull TvSeriesHolder holder, int position) {
         TvResults tv = tvList.get(position);
         holder.title.setText(tv.getName());
-        Picasso.get().load(IMAGE_BASE_URL_500 + tv.getPoster_path()).into(holder.poster);
+        if (tv.getPoster_path() != null) {
+            Picasso.get()
+                    .load(IMAGE_BASE_URL_500 + tv.getPoster_path())
+                    .into(holder.poster);
+        } else {
+            Picasso.get()
+                    .load("https://www.salonlfc.com/wp-content/uploads/2018/01/image-not-found-scaled-1150x647.png")
+                    .into(holder.poster);
+        }
 
         boolean fav = FavoritesManager.isFavorite(context, tv.getId());
         holder.btnFavorite.setImageResource(fav ? android.R.drawable.btn_star_big_on : android.R.drawable.btn_star_big_off);

--- a/app/src/main/java/com/halil/ozel/moviedb/ui/home/fragments/SearchFragment.java
+++ b/app/src/main/java/com/halil/ozel/moviedb/ui/home/fragments/SearchFragment.java
@@ -7,6 +7,9 @@ import android.view.ViewGroup;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.widget.EditText;
+import android.widget.TextView;
+import android.view.inputmethod.InputMethodManager;
+import android.content.Context;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -46,6 +49,7 @@ public class SearchFragment extends Fragment {
     private final List<TvResults> tvList = new ArrayList<>();
     private MovieCastAdapter personAdapter;
     private final List<Cast> personList = new ArrayList<>();
+    private TextView tvMoviesTitle, tvTvTitle, tvPersonsTitle;
 
     @Nullable
     @Override
@@ -54,6 +58,19 @@ public class SearchFragment extends Fragment {
         View view = inflater.inflate(R.layout.fragment_search, container, false);
 
         EditText etQuery = view.findViewById(R.id.etQuery);
+        tvMoviesTitle = view.findViewById(R.id.tvMoviesTitle);
+        tvTvTitle = view.findViewById(R.id.tvTvTitle);
+        tvPersonsTitle = view.findViewById(R.id.tvPersonsTitle);
+
+        tvMoviesTitle.setVisibility(View.GONE);
+        tvTvTitle.setVisibility(View.GONE);
+        tvPersonsTitle.setVisibility(View.GONE);
+
+        etQuery.post(() -> {
+            etQuery.requestFocus();
+            InputMethodManager imm = (InputMethodManager) requireContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+            if (imm != null) imm.showSoftInput(etQuery, InputMethodManager.SHOW_IMPLICIT);
+        });
 
         RecyclerView rvMovies = view.findViewById(R.id.rvSearchMovies);
         rvMovies.setLayoutManager(new LinearLayoutManager(getContext(), LinearLayoutManager.HORIZONTAL, false));
@@ -87,6 +104,9 @@ public class SearchFragment extends Fragment {
                     movieAdapter.notifyDataSetChanged();
                     tvAdapter.notifyDataSetChanged();
                     personAdapter.notifyDataSetChanged();
+                    tvMoviesTitle.setVisibility(View.GONE);
+                    tvTvTitle.setVisibility(View.GONE);
+                    tvPersonsTitle.setVisibility(View.GONE);
                     return;
                 }
 
@@ -101,6 +121,9 @@ public class SearchFragment extends Fragment {
                             if (response.getResults() != null) {
                                 movieList.addAll(response.getResults());
                                 movieAdapter.notifyDataSetChanged();
+                                tvMoviesTitle.setVisibility(movieList.isEmpty() ? View.GONE : View.VISIBLE);
+                            } else {
+                                tvMoviesTitle.setVisibility(View.GONE);
                             }
                         }, e -> Timber.e(e, "Error searching movie: %s", e.getMessage()));
 
@@ -111,6 +134,9 @@ public class SearchFragment extends Fragment {
                             if (response.getResults() != null) {
                                 tvList.addAll(response.getResults());
                                 tvAdapter.notifyDataSetChanged();
+                                tvTvTitle.setVisibility(tvList.isEmpty() ? View.GONE : View.VISIBLE);
+                            } else {
+                                tvTvTitle.setVisibility(View.GONE);
                             }
                         }, e -> Timber.e(e, "Error searching tv: %s", e.getMessage()));
 
@@ -121,6 +147,9 @@ public class SearchFragment extends Fragment {
                             if (response.getResults() != null) {
                                 personList.addAll(response.getResults());
                                 personAdapter.notifyDataSetChanged();
+                                tvPersonsTitle.setVisibility(personList.isEmpty() ? View.GONE : View.VISIBLE);
+                            } else {
+                                tvPersonsTitle.setVisibility(View.GONE);
                             }
                         }, e -> Timber.e(e, "Error searching person: %s", e.getMessage()));
             }

--- a/app/src/main/res/layout/activity_movie_detail.xml
+++ b/app/src/main/res/layout/activity_movie_detail.xml
@@ -222,11 +222,12 @@
 
 
     </androidx.core.widget.NestedScrollView>
-    <com.google.android.material.floatingactionbutton.FloatingActionButton
+    <ImageButton
         android:id="@+id/fabFavorite"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentEnd="true"
+        android:background="@android:color/transparent"
         android:layout_margin="16dp"
         android:src="@android:drawable/btn_star_big_off" />
 

--- a/app/src/main/res/layout/activity_tv_series_detail.xml
+++ b/app/src/main/res/layout/activity_tv_series_detail.xml
@@ -222,11 +222,12 @@
 
 
     </androidx.core.widget.NestedScrollView>
-    <com.google.android.material.floatingactionbutton.FloatingActionButton
+    <ImageButton
         android:id="@+id/fabFavorite"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentEnd="true"
+        android:background="@android:color/transparent"
         android:layout_margin="16dp"
         android:src="@android:drawable/btn_star_big_off" />
 

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -21,6 +21,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:padding="5dp"
+            android:visibility="gone"
             android:text="Movies" />
 
         <androidx.recyclerview.widget.RecyclerView
@@ -34,6 +35,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="10dp"
             android:padding="5dp"
+            android:visibility="gone"
             android:text="TV Series" />
 
         <androidx.recyclerview.widget.RecyclerView
@@ -47,6 +49,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="10dp"
             android:padding="5dp"
+            android:visibility="gone"
             android:text="Persons" />
 
         <androidx.recyclerview.widget.RecyclerView


### PR DESCRIPTION
## Summary
- show section titles on the search screen only when results exist
- focus the search field automatically and show keyboard
- add placeholder poster loading for movies/tv
- display movie and tv titles on detail toolbars
- replace floating action buttons with star image buttons

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6856dcf6e484832b8fab4f91d17aeb3f