### PR TITLE
Fix favorites update and detail toolbar

### DIFF
--- a/app/src/main/java/com/halil/ozel/moviedb/ui/detail/MovieDetailActivity.java
+++ b/app/src/main/java/com/halil/ozel/moviedb/ui/detail/MovieDetailActivity.java
@@ -78,6 +78,9 @@ public class MovieDetailActivity extends Activity {
         btnToggle = findViewById(R.id.btnToggle);
         fabFavorite = findViewById(R.id.fabFavorite);
         detailToolbar = findViewById(R.id.detailToolbar);
+        detailToolbar.setNavigationIcon(androidx.appcompat.R.drawable.abc_ic_ab_back_material);
+        detailToolbar.setNavigationOnClickListener(v -> onBackPressed());
+        detailToolbar.setTitle("");
 
         castDataList = new ArrayList<>();
         castAdapter = new MovieCastAdapter(castDataList, this);
@@ -122,7 +125,6 @@ public class MovieDetailActivity extends Activity {
         title = getIntent().getStringExtra("title");
         id = getIntent().getIntExtra("id", 0);
         tvTitle.setText(title);
-        detailToolbar.setTitle(title);
         tvPopularity.setText(getString(R.string.popularity_format,
                 getIntent().getDoubleExtra("popularity", 0)));
         tvReleaseDate.setText(getString(R.string.release_date_format,

--- a/app/src/main/java/com/halil/ozel/moviedb/ui/detail/TvSeriesDetailActivity.java
+++ b/app/src/main/java/com/halil/ozel/moviedb/ui/detail/TvSeriesDetailActivity.java
@@ -79,6 +79,9 @@ public class TvSeriesDetailActivity extends Activity {
         btnToggle = findViewById(R.id.btnToggle);
         fabFavorite = findViewById(R.id.fabFavorite);
         detailToolbar = findViewById(R.id.detailToolbar);
+        detailToolbar.setNavigationIcon(androidx.appcompat.R.drawable.abc_ic_ab_back_material);
+        detailToolbar.setNavigationOnClickListener(v -> onBackPressed());
+        detailToolbar.setTitle("");
 
         castDataList = new ArrayList<>();
         castAdapter = new MovieCastAdapter(castDataList, this);
@@ -116,7 +119,6 @@ public class TvSeriesDetailActivity extends Activity {
         title = getIntent().getStringExtra("title");
         id = getIntent().getIntExtra("id", 0);
         tvTitle.setText(title);
-        detailToolbar.setTitle(title);
         etvOverview.setText(getIntent().getStringExtra("overview"));
         tvPopularity.setText(getString(R.string.popularity_format,
                 getIntent().getDoubleExtra("popularity", 0)));

--- a/app/src/main/java/com/halil/ozel/moviedb/ui/home/adapters/MovieAdapter.java
+++ b/app/src/main/java/com/halil/ozel/moviedb/ui/home/adapters/MovieAdapter.java
@@ -36,6 +36,7 @@ public class MovieAdapter extends RecyclerView.Adapter<MovieAdapter.PopularMovie
 
     private final List<Results> popularMovieList;
     private final Context context;
+    private OnFavoriteChangeListener favoriteChangeListener;
 
     @Inject
     TMDbAPI tmDbAPI;
@@ -43,6 +44,14 @@ public class MovieAdapter extends RecyclerView.Adapter<MovieAdapter.PopularMovie
     public MovieAdapter(List<Results> popularMovieList, Context context) {
         this.popularMovieList = popularMovieList;
         this.context = context;
+    }
+
+    public interface OnFavoriteChangeListener {
+        void onChange();
+    }
+
+    public void setOnFavoriteChangeListener(OnFavoriteChangeListener listener) {
+        this.favoriteChangeListener = listener;
     }
 
     @NonNull
@@ -74,9 +83,11 @@ public class MovieAdapter extends RecyclerView.Adapter<MovieAdapter.PopularMovie
             if (FavoritesManager.isFavorite(context, results.getId())) {
                 FavoritesManager.remove(context, results.getId());
                 holder.btnFavorite.setImageResource(android.R.drawable.btn_star_big_off);
+                if (favoriteChangeListener != null) favoriteChangeListener.onChange();
             } else {
                 FavoritesManager.add(context, results);
                 holder.btnFavorite.setImageResource(android.R.drawable.btn_star_big_on);
+                if (favoriteChangeListener != null) favoriteChangeListener.onChange();
             }
         });
 

--- a/app/src/main/java/com/halil/ozel/moviedb/ui/home/adapters/TvSeriesAdapter.java
+++ b/app/src/main/java/com/halil/ozel/moviedb/ui/home/adapters/TvSeriesAdapter.java
@@ -87,7 +87,7 @@ public class TvSeriesAdapter extends RecyclerView.Adapter<TvSeriesAdapter.TvSeri
                     Intent intent = new Intent(view.getContext(), TvSeriesDetailActivity.class);
                     intent.putExtra("id", tv.getId());
                     intent.putExtra("title", tv.getName());
-                    intent.putExtra("backdrop", "");
+                    intent.putExtra("backdrop", response.getBackdrop_path());
                     intent.putExtra("poster", tv.getPoster_path());
                     intent.putExtra("overview", response instanceof ResponseTvSeriesDetail ? ((ResponseTvSeriesDetail) response).getOverview() : "");
                     intent.putExtra("popularity", response.getPopularity());

--- a/app/src/main/java/com/halil/ozel/moviedb/ui/home/fragments/FavoriteFragment.java
+++ b/app/src/main/java/com/halil/ozel/moviedb/ui/home/fragments/FavoriteFragment.java
@@ -44,6 +44,7 @@ public class FavoriteFragment extends Fragment {
     private void loadData() {
         List<Results> list = FavoritesManager.load(requireContext());
         adapter = new MovieAdapter(list, getContext());
+        adapter.setOnFavoriteChangeListener(this::loadData);
         recyclerView.setAdapter(adapter);
     }
 }


### PR DESCRIPTION
## Summary
- update favorites screen when favorite status changes
- show back arrow in detail toolbars and remove title text
- send `backdrop` to TV details so horizontal poster displays

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6856df8989c8832bbe4f25a7949e75db