### PR TITLE
Improve cast card and season dropdown UX

### DIFF
--- a/app/src/main/res/layout/activity_tv_series_detail.xml
+++ b/app/src/main/res/layout/activity_tv_series_detail.xml
@@ -176,23 +176,29 @@
 
                 <com.google.android.material.textfield.TextInputLayout
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
+                    android:layout_height="wrap_content"
+                    app:endIconMode="dropdown_menu"
+                    android:hint="Season">
 
                     <AutoCompleteTextView
                         android:id="@+id/spSeason"
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content" />
+                        android:layout_height="wrap_content"
+                        android:inputType="none" />
                 </com.google.android.material.textfield.TextInputLayout>
 
                 <com.google.android.material.textfield.TextInputLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp">
+                    android:layout_marginTop="8dp"
+                    app:endIconMode="dropdown_menu"
+                    android:hint="Episode">
 
                     <AutoCompleteTextView
                         android:id="@+id/spEpisode"
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content" />
+                        android:layout_height="wrap_content"
+                        android:inputType="none" />
                 </com.google.android.material.textfield.TextInputLayout>
 
             </LinearLayout>

--- a/app/src/main/res/layout/row_cast.xml
+++ b/app/src/main/res/layout/row_cast.xml
@@ -12,8 +12,10 @@
         xmlns:card_view="http://schemas.android.com/apk/res-auto"
         android:layout_width="100dp"
         android:layout_height="150dp"
-        card_view:cardCornerRadius="4dp"
-        card_view:cardElevation="2dp">
+        card_view:cardCornerRadius="8dp"
+        card_view:cardElevation="4dp"
+        android:foreground="?attr/selectableItemBackground"
+        app:cardUseCompatPadding="true">
 
         <LinearLayout
             android:layout_width="wrap_content"
@@ -21,7 +23,7 @@
             android:orientation="vertical">
 
             <ImageView
-                android:scaleType="fitXY"
+                android:scaleType="centerCrop"
                 android:id="@+id/ivCastPoster"
                 android:layout_width="wrap_content"
                 android:layout_height="150dp"


### PR DESCRIPTION
## Summary
- modernize cast item design with bigger radius, elevation, and ripple effect
- add drop-down icons and hints for season/episode selectors

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6856ecdc0300832b8dcfc1d5849c89a3