### PR TITLE
Add detailed season and episode views

### DIFF
--- a/app/src/main/java/com/halil/ozel/moviedb/data/Api/TMDbAPI.java
+++ b/app/src/main/java/com/halil/ozel/moviedb/data/Api/TMDbAPI.java
@@ -100,6 +100,14 @@ public interface TMDbAPI {
             @Query("api_key") String api_key
     );
 
+    @GET(HttpClientModule.TV_DETAILS + "{tv_id}/season/{season_number}/episode/{episode_number}")
+    Observable<Episode> getEpisodeDetail(
+            @Path("tv_id") int tvId,
+            @Path("season_number") int seasonNumber,
+            @Path("episode_number") int episodeNumber,
+            @Query("api_key") String api_key
+    );
+
     @GET(HttpClientModule.GENRE_MOVIE)
     Observable<ResponseGenreList> getMovieGenres(
             @Query("api_key") String api_key

--- a/app/src/main/java/com/halil/ozel/moviedb/data/models/Episode.java
+++ b/app/src/main/java/com/halil/ozel/moviedb/data/models/Episode.java
@@ -5,6 +5,8 @@ import java.io.Serializable;
 public class Episode implements Serializable {
     private Integer episode_number;
     private String name;
+    private String overview;
+    private String still_path;
 
     public Integer getEpisode_number() {
         return episode_number;
@@ -20,5 +22,21 @@ public class Episode implements Serializable {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public String getOverview() {
+        return overview;
+    }
+
+    public void setOverview(String overview) {
+        this.overview = overview;
+    }
+
+    public String getStill_path() {
+        return still_path;
+    }
+
+    public void setStill_path(String still_path) {
+        this.still_path = still_path;
     }
 }

--- a/app/src/main/java/com/halil/ozel/moviedb/data/models/ResponseSeasonDetail.java
+++ b/app/src/main/java/com/halil/ozel/moviedb/data/models/ResponseSeasonDetail.java
@@ -5,6 +5,9 @@ import java.util.List;
 
 public class ResponseSeasonDetail implements Serializable {
     private List<Episode> episodes;
+    private String name;
+    private String overview;
+    private String poster_path;
 
     public List<Episode> getEpisodes() {
         return episodes;
@@ -12,5 +15,29 @@ public class ResponseSeasonDetail implements Serializable {
 
     public void setEpisodes(List<Episode> episodes) {
         this.episodes = episodes;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getOverview() {
+        return overview;
+    }
+
+    public void setOverview(String overview) {
+        this.overview = overview;
+    }
+
+    public String getPoster_path() {
+        return poster_path;
+    }
+
+    public void setPoster_path(String poster_path) {
+        this.poster_path = poster_path;
     }
 }

--- a/app/src/main/res/layout/dialog_episode_detail.xml
+++ b/app/src/main/res/layout/dialog_episode_detail.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:padding="16dp"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <ImageView
+        android:id="@+id/ivEpisodeStill"
+        android:layout_width="match_parent"
+        android:layout_height="200dp"
+        android:scaleType="centerCrop" />
+
+    <TextView
+        android:id="@+id/tvEpisodeName"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/tvEpisodeOverview"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/dialog_season_detail.xml
+++ b/app/src/main/res/layout/dialog_season_detail.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:padding="16dp"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <ImageView
+        android:id="@+id/ivSeasonPoster"
+        android:layout_width="match_parent"
+        android:layout_height="200dp"
+        android:scaleType="centerCrop" />
+
+    <TextView
+        android:id="@+id/tvSeasonName"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/tvSeasonOverview"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp" />
+
+</LinearLayout>


### PR DESCRIPTION
## Summary
- extend `Episode` and `ResponseSeasonDetail` models to hold extra info
- add TMDb API call for episode details
- implement dialogs in `TvSeriesDetailActivity` showing season and episode info when selected
- include dialog layouts for season and episode

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6856f4423be8832ba190a8f9f8c5617e