### PR TITLE
Fix detail screen back button visibility

### DIFF
--- a/app/src/main/java/com/halil/ozel/moviedb/ui/detail/CastDetailActivity.java
+++ b/app/src/main/java/com/halil/ozel/moviedb/ui/detail/CastDetailActivity.java
@@ -5,6 +5,8 @@ import static com.halil.ozel.moviedb.data.Api.TMDbAPI.TMDb_API_KEY;
 
 import androidx.appcompat.app.AppCompatActivity;
 import android.os.Bundle;
+import com.google.android.material.appbar.MaterialToolbar;
+import androidx.core.content.ContextCompat;
 import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -47,6 +49,8 @@ public class CastDetailActivity extends AppCompatActivity {
     private final java.util.List<Results> movieList = new java.util.ArrayList<>();
     private final java.util.List<TvResults> tvList = new java.util.ArrayList<>();
 
+    private MaterialToolbar detailToolbar;
+
     private int personId;
 
     @Override
@@ -54,6 +58,12 @@ public class CastDetailActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         App.instance().appComponent().inject(this);
         setContentView(R.layout.activity_cast_detail);
+
+        detailToolbar = findViewById(R.id.detailToolbar);
+        detailToolbar.setNavigationIcon(androidx.appcompat.R.drawable.abc_ic_ab_back_material);
+        detailToolbar.setNavigationOnClickListener(v -> onBackPressed());
+        detailToolbar.setTitle("");
+        detailToolbar.setNavigationIconTint(ContextCompat.getColor(this, android.R.color.white));
 
         ivProfile = findViewById(R.id.ivProfile);
         tvName = findViewById(R.id.tvName);

--- a/app/src/main/java/com/halil/ozel/moviedb/ui/detail/MovieDetailActivity.java
+++ b/app/src/main/java/com/halil/ozel/moviedb/ui/detail/MovieDetailActivity.java
@@ -81,6 +81,7 @@ public class MovieDetailActivity extends AppCompatActivity {
         detailToolbar.setNavigationIcon(androidx.appcompat.R.drawable.abc_ic_ab_back_material);
         detailToolbar.setNavigationOnClickListener(v -> onBackPressed());
         detailToolbar.setTitle("");
+        detailToolbar.setNavigationIconTint(getResources().getColor(android.R.color.white));
 
         castDataList = new ArrayList<>();
         castAdapter = new MovieCastAdapter(castDataList, this);

--- a/app/src/main/java/com/halil/ozel/moviedb/ui/detail/TvSeriesDetailActivity.java
+++ b/app/src/main/java/com/halil/ozel/moviedb/ui/detail/TvSeriesDetailActivity.java
@@ -91,6 +91,7 @@ public class TvSeriesDetailActivity extends AppCompatActivity {
         detailToolbar.setNavigationIcon(androidx.appcompat.R.drawable.abc_ic_ab_back_material);
         detailToolbar.setNavigationOnClickListener(v -> onBackPressed());
         detailToolbar.setTitle("");
+        detailToolbar.setNavigationIconTint(getResources().getColor(android.R.color.white));
 
         castDataList = new ArrayList<>();
         castAdapter = new MovieCastAdapter(castDataList, this);

--- a/app/src/main/res/layout/activity_cast_detail.xml
+++ b/app/src/main/res/layout/activity_cast_detail.xml
@@ -1,13 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <LinearLayout
-        android:orientation="vertical"
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/detailToolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="16dp">
+        android:background="?attr/colorPrimary"
+        android:title="@string/app_name"
+        android:titleTextColor="@android:color/white"
+        app:navigationIconTint="@android:color/white" />
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <LinearLayout
+            android:orientation="vertical"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="16dp">
 
         <ImageView
             android:id="@+id/ivProfile"
@@ -66,3 +81,4 @@
 
     </LinearLayout>
 </ScrollView>
+    </LinearLayout>

--- a/app/src/main/res/layout/activity_movie_detail.xml
+++ b/app/src/main/res/layout/activity_movie_detail.xml
@@ -15,7 +15,8 @@
         android:layout_height="wrap_content"
         android:background="?attr/colorPrimary"
         android:titleTextColor="@android:color/white"
-        android:title="@string/app_name" />
+        android:title="@string/app_name"
+        app:navigationIconTint="@android:color/white" />
 
     <androidx.core.widget.NestedScrollView
         android:id="@+id/svDetail"

--- a/app/src/main/res/layout/activity_tv_series_detail.xml
+++ b/app/src/main/res/layout/activity_tv_series_detail.xml
@@ -15,7 +15,8 @@
         android:layout_height="wrap_content"
         android:background="?attr/colorPrimary"
         android:titleTextColor="@android:color/white"
-        android:title="@string/app_name" />
+        android:title="@string/app_name"
+        app:navigationIconTint="@android:color/white" />
 
     <androidx.core.widget.NestedScrollView
         android:id="@+id/svDetail"


### PR DESCRIPTION
## Summary
- add toolbar with back navigation in cast detail screen
- tint toolbar back icon to white for consistency
- ensure movie and TV detail screens tint back icon properly

## Testing
- `./gradlew test --quiet` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6856f47ce100832b9675341c6d4f5b0c