### PR TITLE
Add padding to season/episode fields

### DIFF
--- a/app/src/main/res/layout/activity_tv_series_detail.xml
+++ b/app/src/main/res/layout/activity_tv_series_detail.xml
@@ -167,6 +167,7 @@
                     android:layout_marginStart="4dp"
                     android:layout_marginTop="5dp"
                     android:layout_marginEnd="4dp"
+                    android:paddingStart="16dp"
                     android:maxLines="3"
                     android:textColor="?android:textColorPrimary" />
 
@@ -177,6 +178,7 @@
                     android:layout_marginStart="4dp"
                     android:layout_marginTop="5dp"
                     android:layout_marginEnd="4dp"
+                    android:paddingStart="16dp"
                     android:maxLines="3"
                     android:textColor="?android:textColorPrimary" />
 
@@ -190,7 +192,8 @@
                         android:id="@+id/spSeason"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:inputType="none" />
+                        android:inputType="none"
+                        android:paddingStart="16dp" />
                 </com.google.android.material.textfield.TextInputLayout>
 
                 <com.google.android.material.textfield.TextInputLayout
@@ -204,7 +207,8 @@
                         android:id="@+id/spEpisode"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:inputType="none" />
+                        android:inputType="none"
+                        android:paddingStart="16dp" />
                 </com.google.android.material.textfield.TextInputLayout>
 
             </LinearLayout>


### PR DESCRIPTION
## Summary
- adjust `tvSeasons` and `tvEpisodes` text blocks to include start padding
- pad season and episode drop-down fields so text isn't flush against the left side

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6856f5c99c58832bb2bf9004ffe9260d