### PR TITLE
Fix language & dark mode handling

### DIFF
--- a/app/src/main/java/com/halil/ozel/moviedb/App.java
+++ b/app/src/main/java/com/halil/ozel/moviedb/App.java
@@ -2,9 +2,9 @@ package com.halil.ozel.moviedb;
 
 import android.app.Application;
 import android.content.SharedPreferences;
-import android.content.res.Configuration;
 import java.util.Locale;
 import androidx.appcompat.app.AppCompatDelegate;
+import androidx.core.os.LocaleListCompat;
 
 import com.halil.ozel.moviedb.dagger.components.ApplicationComponent;
 import com.halil.ozel.moviedb.dagger.components.DaggerApplicationComponent;
@@ -52,8 +52,7 @@ public class App extends Application {
     public void applyLocale(String lang) {
         Locale locale = new Locale(lang);
         Locale.setDefault(locale);
-        Configuration config = getResources().getConfiguration();
-        config.setLocale(locale);
-        getResources().updateConfiguration(config, getResources().getDisplayMetrics());
+        LocaleListCompat locales = LocaleListCompat.create(locale);
+        AppCompatDelegate.setApplicationLocales(locales);
     }
 }

--- a/app/src/main/java/com/halil/ozel/moviedb/ui/home/fragments/SettingsFragment.java
+++ b/app/src/main/java/com/halil/ozel/moviedb/ui/home/fragments/SettingsFragment.java
@@ -52,8 +52,14 @@ public class SettingsFragment extends Fragment {
         boolean dark = requireContext().getSharedPreferences(PREFS, 0).getBoolean(KEY_DARK, false);
         themeSwitch.setChecked(dark);
         themeSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> {
-            requireContext().getSharedPreferences(PREFS, 0).edit().putBoolean(KEY_DARK, isChecked).apply();
-            AppCompatDelegate.setDefaultNightMode(isChecked ? AppCompatDelegate.MODE_NIGHT_YES : AppCompatDelegate.MODE_NIGHT_NO);
+            requireContext().getSharedPreferences(PREFS, 0)
+                    .edit()
+                    .putBoolean(KEY_DARK, isChecked)
+                    .apply();
+            AppCompatDelegate.setDefaultNightMode(isChecked
+                    ? AppCompatDelegate.MODE_NIGHT_YES
+                    : AppCompatDelegate.MODE_NIGHT_NO);
+            requireActivity().recreate();
         });
 
         return view;


### PR DESCRIPTION
## Summary
- handle locale using `AppCompatDelegate.setApplicationLocales`
- refresh activity when toggling dark mode

## Testing
- `./gradlew test --quiet` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6856f6e5c368832b851e0b5fabb5ca53