### PR TITLE
Fix Favorites star alignment

### DIFF
--- a/app/src/main/res/layout/row_nowplaying_movie.xml
+++ b/app/src/main/res/layout/row_nowplaying_movie.xml
@@ -28,7 +28,8 @@
                 android:id="@+id/btnFavorite"
                 android:layout_width="24dp"
                 android:layout_height="24dp"
-                android:layout_gravity="end"
+                android:layout_gravity="end|top"
+                android:layout_margin="4dp"
                 android:background="@android:color/transparent"
                 android:src="@drawable/ic_star_border_24"
                 app:srcCompat="@drawable/ic_star_border_24" />

--- a/app/src/main/res/layout/row_recommend_movie.xml
+++ b/app/src/main/res/layout/row_recommend_movie.xml
@@ -28,7 +28,8 @@
                 android:id="@+id/btnFavorite"
                 android:layout_width="24dp"
                 android:layout_height="24dp"
-                android:layout_gravity="end"
+                android:layout_gravity="end|top"
+                android:layout_margin="4dp"
                 android:background="@android:color/transparent"
                 android:src="@drawable/ic_star_border_24"
                 app:srcCompat="@drawable/ic_star_border_24" />

--- a/app/src/main/res/layout/row_tvseries.xml
+++ b/app/src/main/res/layout/row_tvseries.xml
@@ -26,7 +26,8 @@
                 android:id="@+id/btnFavorite"
                 android:layout_width="24dp"
                 android:layout_height="24dp"
-                android:layout_gravity="end"
+                android:layout_gravity="end|top"
+                android:layout_margin="4dp"
                 android:background="@android:color/transparent"
                 android:src="@drawable/ic_star_border_24"
                 app:srcCompat="@drawable/ic_star_border_24" />


### PR DESCRIPTION
## Summary
- tweak image button layout for movie items so star icons use `end|top` gravity and add margin

## Testing
- `./gradlew test --continue` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6856fa85a4fc832bae1a3a305318eda9